### PR TITLE
Make uri optional on fileChange object.

### DIFF
--- a/document/CoreFormat.mdk
+++ b/document/CoreFormat.mdk
@@ -1107,8 +1107,10 @@ A `fileChange` object represents a change to a single file.
 
 ### `uri` property { #fileChange-uri }
 
-A `fileChange` object shall contain a property named `uri` whose value is a string value that represents
-the location of the file as a valid URI.
+A `fileChange` object may contain a property named `uri` whose value is a string value that represents
+the location of the file as a valid URI. If the 'uri' property is not present, its value is assumed
+to be the uri that is associated with the current result (i.e., the uri present on the result 
+'analysisTarget' property or, if present, the uri of the result 'resultFile' property).
 
 ### `replacements` property { #fileChange-replacements }
 


### PR DESCRIPTION
#46

In the majority of cases, a fix will related to the file that is associated with the current result. So, we make a fileChange uri optional. If not present, we assume this value to be the result uri. The result uri is either the resultFile.uri property (if present), otherwise it is the analysisResult.uri property (which is always present, by spec)

@lgolding @nguerrera 
