### PR TITLE
Remove hash link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sarif-spec
 This repo contains the draft of the specification document for the Static Analysis Results Interchange Format (SARIF).
-The current HTML is always available [here](https://rawgit.com/sarif-standard/sarif-spec/master/Static%20Analysis%20Results%20Interchange%20Format%20(SARIF).html#result-codeflows).
+The current HTML is always available [here](https://rawgit.com/sarif-standard/sarif-spec/master/Static%20Analysis%20Results%20Interchange%20Format%20(SARIF).html).
 
 ## Please read the license
 


### PR DESCRIPTION
The URL pointing at the spec has a hash-link to a subsection, which is slightly annoying.  Removing it.  Thanks.